### PR TITLE
Add K02 sample settings to wave headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,69 +22,168 @@
     <button style="display: none;" id="processButton">Resample Audio</button>
     <a id="downloadLink" style="display: none;">Download </a>
     </div>
-    <div class="options">
-      <div class="items">
-        <div class="fidelity">
-          <p><b>Fidelity</b></p>
+    <div class="information items">
+      <div class="fidelity">
+        <p><b>Fidelity</b></p>
+      <div>
+          <input type="radio" id="sd" name="fidelity" value="sd" checked />
+          <label for="sd">CD (16/46)</label>
+        </div>
+
         <div>
-            <input type="radio" id="sd" name="fidelity" value="sd" checked />
-            <label for="sd">CD (16/46)</label>
-          </div>
+          <input type="radio" id="SP-1200" name="fidelity" value="SP-1200" />
+          <label for="SP-1200">SP-1200 8 Bit (8/26)</label>
+        </div>
+        <div>
+          <input type="radio" id="SP-1201" name="fidelity" value="SP-1201" />
+          <label for="SP-1201">SP-1200 16 Bit (16/26)</label>
+        </div>
+        <div>
+          <input type="radio" id="SK-1" name="fidelity" value="SK-1" />
+          <label for="SK-1">SK-1 (8/9)</label>
+        </div>
+      </div>
+      <div class="speed">
+        <p><b>Speed</b></p>
+        <div>
+          <input type="radio" id="1x" name="speed" value="1x" checked />
+          <label for="1x">1x</label>
+        </div>
+        <div>
+          <input type="radio" id="2x" name="speed" value="2x" />
+          <label for="2x">2x</label>
+        </div>
+        <div>
+          <input type="radio" id="4x" name="speed" value="4x" />
+          <label for="4x">4x</label>
+        </div>
+      </div>
+      <div class="channels">
+        <p><b>Channels</b></p>
+        <div>
+          <input type="radio" id="2" name="channels" value="2" checked/>
+          <label for="2">Stereo</label>
+        </div>
+        <div>
+          <input type="radio" id="1" name="channels" value="1"/>
+          <label for="1">Mono</label>
+        </div>
 
-          <div>
-            <input type="radio" id="SP-1200" name="fidelity" value="SP-1200" />
-            <label for="SP-1200">SP-1200 8 Bit (8/26)</label>
-          </div>
-          <div>
-            <input type="radio" id="SP-1201" name="fidelity" value="SP-1201" />
-            <label for="SP-1201">SP-1200 16 Bit (16/26)</label>
-          </div>
-          <div>
-            <input type="radio" id="SK-1" name="fidelity" value="SK-1" />
-            <label for="SK-1">SK-1 (8/9)</label>
-          </div>
+      </div>
+      <div class="filename">
+        <p><b>Rename File?</b></p>
+        <div>
+          <input type="radio" id="1" name="filename" value="true" checked/>
+          <label for="1">Rename to BPM and Key</label>
         </div>
-        <div class="speed">
-          <p><b>Speed</b></p>
-          <div>
-            <input type="radio" id="1x" name="speed" value="1x" checked />
-            <label for="1x">1x</label>
-          </div>
-          <div>
-            <input type="radio" id="2x" name="speed" value="2x" />
-            <label for="2x">2x</label>
-          </div>
-          <div>
-            <input type="radio" id="4x" name="speed" value="4x" />
-            <label for="4x">4x</label>
-          </div>
-        </div>
-        <div class="channels">
-          <p><b>Channels</b></p>
-          <div>
-            <input type="radio" id="2" name="channels" value="2" checked/>
-            <label for="2">Stereo</label>
-          </div>
-          <div>
-            <input type="radio" id="1" name="channels" value="1"/>
-            <label for="1">Mono</label>
-          </div>
-
-        </div>
-        <div class="filename">
-          <p><b>Rename File?</b></p>
-          <div>
-            <input type="radio" id="1" name="filename" value="true" checked/>
-            <label for="1">Rename to BPM and Key</label>
-          </div>
-          <div>
-            <input type="radio" id="2" name="filename" value="false"/>
-            <label for="2">Keep Original Filename</label>
-          </div>
+        <div>
+          <input type="radio" id="2" name="filename" value="false"/>
+          <label for="2">Keep Original Filename</label>
         </div>
       </div>
     </div>
+    <form id="ko2Form">
+      <details class="information" open>
+        <summary>
+          <b>EP-133 KO II Settings</b>
+          <input type="checkbox" role="switch" id="ko2FormToggle" checked style="margin-left: 2em;">
+        </summary>
 
+        <fieldset id="ko2FormFieldset" class="items">
+          <p class="volume-slider">
+            <output class="price-output" for="sound.amplitude"></output>
+            <input type="range" orient="vertical" name="sound.amplitude" id="sound.amplitude" value="90" min="0" max="200" list="amplitudelist" />
+            <label for="sound.amplitude"><b>Volume</b></label>
+            <datalist id="amplitudelist">
+              <option value="0">0</option>
+              <option value="90">90</option>
+              <option value="200">200</option>
+            </datalist>
+          </p>
+          <div class="grid-container">
+            <div>
+              <label for="sound.pan">
+                <b>Pan</b>
+                <output class="price-output" for="sound.pan"></output>
+              </label>
+              <input type="range" name="sound.pan" id="sound.pan" value="0" min="-16" max="16" list="panlist"/>
+              <datalist id="panlist">
+                <option value="-16">L</option>
+                <option value="0">C</option>
+                <option value="16">R</option>
+              </datalist>
+            </div>
+            <div>
+              <label for="sound.pitch">
+                <b>Pitch</b>
+                <output class="price-output" for="sound.pitch"></output>
+              </label>
+              <input type="range" name="sound.pitch" id="sound.pitch" value="0" min="-12" max="12" list="pitchlist" style="margin-bottom: 2em" />
+              <datalist id="pitchlist">
+                <option value="-12">-12</option>
+                <option value="0">0</option>
+                <option value="12">12</option>
+              </datalist>
+            </div>
+
+            <div>
+              <label for="envelope.attack">
+                <b>Attack</b>
+                <output class="price-output" for="envelope.attack"></output>
+              </label>
+              <input type="range" name="envelope.attack" id="envelope.attack" value="0" min="0" max="255" />
+            </div>
+            <div>
+              <label for="envelope.release">
+                <b>Release</b>
+                <output class="price-output" for="envelope.release"></output>
+              </label>
+              <input type="range" name="envelope.release" id="envelope.release" value="128" min="0" max="255" />
+            </div>
+          </div>
+
+          <div>
+            <p><b>Playmode</b></p>
+            <div>
+              <input type="radio" id="sound.playmode.oneshot" name="sound.playmode" value="oneshot" />
+              <label for="sound.playmode.oneshot">Oneshot</label>
+            </div>
+            <div>
+              <input type="radio" id="sound.playmode.key" name="sound.playmode" value="key" checked />
+              <label for="sound.playmode.key">Key</label>
+            </div>
+            <div style="margin-bottom: 1.8em">
+              <input type="radio" id="sound.playmode.legato" name="sound.playmode" value="legato" />
+              <label for="sound.playmode.legato">Legato</label>
+            </div>
+
+            <div>
+              <p><label for="sound.rootnote"><b>Rootnote</b></label></p>
+              <input type="number" name="sound.rootnote" id="sound.rootnote" value="60" min="0" max="127" />
+              <output class="price-output" for="sound.rootnote"></output>
+            </div>
+          </div>
+
+          <div>
+            <p><b>Time Stretch</b></p>
+            <div>
+              <input type="radio" id="time.mode.off" name="time.mode" value="off" checked/>
+              <label for="time.mode.off">Off</label>
+            </div>
+            <div>
+              <input type="radio" id="time.mode.bpm" name="time.mode" value="bpm" />
+              <label for="time.mode.bpm">BPM</label>
+            </div>
+            <div>
+              <input type="radio" id="time.mode.bar" name="time.mode" value="bar" />
+              <label for="time.mode.bar">Bar</label>
+            </div>
+          </div>
+        </fieldset>
+
+        <p><i>These options set the default playback style when the sample loads in the Teenage Engineering KO II. They are ignored in other samplers.</i></p>
+      </details>
+    </form>
 
     <div class="information">
       <div class="section 1">

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
   
       <div class="section 3">
           <h2>Why Does This Exist?</h2>
-          <p>Speeding up audio samples is an old trick dating back to the first hardware samplers such as the <a href="https://en.wikipedia.org/wiki/E-mu_SP-1200">Emu SP-1200</a> and <a href="https://de.wikipedia.org/wiki/Akai_MPC_60">Akai MPC 60</a>. It was used to get around memory limitations. These days, it's useful for the <a href="https://www.roland.com/global/products/sp-404mk2/">Roland SP-404</a> or the <a href="https://teenage.engineering/products/ep-133">Teenage Engineering OP-133 KO II.</a> Now you're asking yourself, "Can't I do this with my DAW?" Sure, you could, but this is a drag & drop solution, and no one forces you to use it anyway.</p>
+          <p>Speeding up audio samples is an old trick dating back to the first hardware samplers such as the <a href="https://en.wikipedia.org/wiki/E-mu_SP-1200">Emu SP-1200</a> and <a href="https://de.wikipedia.org/wiki/Akai_MPC_60">Akai MPC 60</a>. It was used to get around memory limitations. These days, it's useful for the <a href="https://www.roland.com/global/products/sp-404mk2/">Roland SP-404</a> or the <a href="https://teenage.engineering/products/ep-133">Teenage Engineering EP-133 KO II.</a> Now you're asking yourself, "Can't I do this with my DAW?" Sure, you could, but this is a drag & drop solution, and no one forces you to use it anyway.</p>
       </div>
       <div class="section">
           <h2>How Does This Work?</h2>

--- a/index.html
+++ b/index.html
@@ -92,11 +92,11 @@
         <fieldset id="ko2FormFieldset" class="items">
           <p class="volume-slider">
             <output class="price-output" for="sound.amplitude"></output>
-            <input type="range" orient="vertical" name="sound.amplitude" id="sound.amplitude" value="90" min="0" max="200" list="amplitudelist" />
+            <input type="range" orient="vertical" name="sound.amplitude" id="sound.amplitude" value="100" min="0" max="200" list="amplitudelist" />
             <label for="sound.amplitude"><b>Volume</b></label>
             <datalist id="amplitudelist">
               <option value="0">0</option>
-              <option value="90">90</option>
+              <option value="100">100</option>
               <option value="200">200</option>
             </datalist>
           </p>

--- a/style.css
+++ b/style.css
@@ -41,21 +41,9 @@ h1 {
   justify-content: center;
 }
 
-.options {
-  width: 100vw;
-  display: flex;
-  justify-content: center;
-}
-
 .items {
   display: flex;
-  justify-content: space-around;
-
-}
-
-.items div{
-  margin-left: 15px;
-  margin-right: 15px;
+  justify-content: space-between;
 }
 
 label{
@@ -66,6 +54,83 @@ label{
   padding-left: 20%;
   padding-right: 20%;
   text-align: justify;
+  margin-bottom: 2em;
+}
+
+summary {
+  display: flex;
+  align-items: center;
+}
+
+fieldset {
+  border: unset;
+  margin: unset;
+  padding: unset;
+}
+
+fieldset:disabled {
+  opacity: .35;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: 1em;
+  row-gap: .66em;
+  margin-block-start: 1em;
+  align-items: flex-start;
+}
+
+.grid-container > div {
+  display: contents;
+}
+
+.grid-container label {
+  display: flex;
+  justify-content: space-between;
+  gap: 1em;
+}
+
+.volume-slider {
+  text-align: center;
+}
+
+input[type=range][orient=vertical] {
+  direction: rtl;
+  appearance: slider-vertical;
+  width: 2em;
+  height: 10.1em;
+  vertical-align: bottom;
+  display: block;
+  margin: 1em auto;
+}
+
+input[role="switch"] {
+  height: 1.5em;
+  width: 3em;
+  margin-top: .25em;
+  vertical-align: top;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  border: 1px solid rgba(0,0,0,.25);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.25%29'/%3e%3c/svg%3e");
+  background-position: left center;
+  border-radius: 2em;
+  transition: background-position .15s ease-in-out;
+}
+
+input[role="switch"]:checked {
+  background-position: right center;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}
+
+.price-output {
+  font-variant-numeric: tabular-nums;
 }
 
 .section {


### PR DESCRIPTION
👋 Hi! I really like this tool and use it frequently for the same reasons you built it.

I was loading a pile of samples in my KO2 this weekend and found I needed to adjust a lot of the settings to get them just right. It takes a fair bit of time and they get completely reset when the sample changes.

I noticed several of the default KO2 samples had some hidden metadata that set better defaults. For example, `403 e bass round.wav` is tuned to E automatically when pressing keys. And many other samples default to `key` or `legato` instead of `oneshot`. I did some reverse-engineering and uncovered the `TNGE` subchunk in the wave file, as well as the parameters that can be saved.

This PR adds a subform to your page that includes the adjustable KO2 settings. We can adjust the settings and they get saved as a subchunk in the WAV header, which is automatically read by the KO2 (when the samples are uploaded through the [Sample Tool](https://teenage.engineering/apps/ep-sample-tool)).

![Screenshot 2025-03-05 at 9 30 56 AM](https://github.com/user-attachments/assets/f04423a1-cfcf-46e9-b34b-b5720cd51580)

The form is in a `<details>` component so it can be closed/hidden for people who aren't using this for the KO2. The form can also be disabled so no additional data is inserted into the WAV header, though it's not a problem for the data to exist.

Thanks for putting this together and I hope you like the addition!

